### PR TITLE
Add office image to content sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,11 +21,13 @@
   <section id="about">
     <h2>会社概要</h2>
     <p>未来テック株式会社は、最先端の技術で未来を創造する企業です。</p>
+    <img src="https://via.placeholder.com/600x400?text=office" alt="オフィスの外観">
   </section>
 
   <section id="services">
     <h2>サービス紹介</h2>
     <p>クラウドソリューションやAI開発など、幅広いサービスを提供しています。</p>
+    <img src="https://via.placeholder.com/600x400?text=office" alt="オフィスの外観">
   </section>
 
   <section id="contact">


### PR DESCRIPTION
## Summary
- insert a placeholder office image in the About and Services sections

## Testing
- `npm test` *(fails: missing `package.json`)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6849370f6f908328b9e6f482504998e3