### PR TITLE
Add about/services/contact pages with dropdown nav

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>会社概要 - 未来テック株式会社</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>未来テック株式会社</h1>
+    <nav>
+      <button class="nav-toggle" id="navToggle" aria-label="メニュー">MENU</button>
+      <ul id="navList">
+        <li><a href="index.html#about">会社概要</a></li>
+        <li><a href="index.html#services">サービス紹介</a></li>
+        <li><a href="index.html#contact">お問い合わせ</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <section class="page-section about-section">
+    <h2>会社概要</h2>
+    <p>未来テック株式会社は、最先端のテクノロジーを活用し、
+クラウドソリューション、AI開発、業務効率化支援など、
+幅広いサービスでお客様の課題解決を支援します。</p>
+  </section>
+
+  <footer>
+    <p>© 2025 未来テック株式会社</p>
+  </footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>お問い合わせ - 未来テック株式会社</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>未来テック株式会社</h1>
+    <nav>
+      <button class="nav-toggle" id="navToggle" aria-label="メニュー">MENU</button>
+      <ul id="navList">
+        <li><a href="index.html#about">会社概要</a></li>
+        <li><a href="index.html#services">サービス紹介</a></li>
+        <li><a href="index.html#contact">お問い合わせ</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <section class="page-section">
+    <h2>お問い合わせ</h2>
+    <p>ご質問やご相談は、下記メールアドレスまでお気軽にお問い合わせください。</p>
+    <p><a href="mailto:info@mirai-tech.co.jp">info@mirai-tech.co.jp</a></p>
+  </section>
+
+  <footer>
+    <p>© 2025 未来テック株式会社</p>
+  </footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,8 @@
   <header>
     <h1>未来テック株式会社</h1>
     <nav>
-      <ul>
+      <button class="nav-toggle" id="navToggle" aria-label="メニュー">MENU</button>
+      <ul id="navList">
         <li><a href="#about">会社概要</a></li>
         <li><a href="#services">サービス紹介</a></li>
         <li><a href="#contact">お問い合わせ</a></li>
@@ -18,26 +19,28 @@
     </nav>
   </header>
 
-  <section id="about">
-    <h2>会社概要</h2>
-    <p>未来テック株式会社は、最先端の技術で未来を創造する企業です。</p>
-    <img src="https://user0514.cdnw.net/shared/img/thumb/textHFKE0400_TP_V.jpg" alt="オフィスの外観">
-  </section>
+  <a href="about.html" class="section-link"><section id="about" class="about-section">
+      <h2>会社概要</h2>
+      <p>未来テック株式会社は、最先端のテクノロジーを活用し、
+クラウドソリューション、AI開発、業務効率化支援など、
+幅広いサービスでお客様の課題解決を支援します。</p>
+    </section></a>
 
-  <section id="services">
+  <a href="services.html" class="section-link"><section id="services">
     <h2>サービス紹介</h2>
     <p>クラウドソリューションやAI開発など、幅広いサービスを提供しています。</p>
     <img src="https://via.placeholder.com/600x400?text=office" alt="オフィスの外観">
-  </section>
+  </section></a>
 
-  <section id="contact">
+  <a href="contact.html" class="section-link"><section id="contact">
     <h2>お問い合わせ</h2>
     <p>ご質問やご相談は、下記メールアドレスまでお気軽にお問い合わせください。</p>
     <p><a href="mailto:info@mirai-tech.co.jp">info@mirai-tech.co.jp</a></p>
-  </section>
+  </section></a>
 
   <footer>
     <p>© 2025 未来テック株式会社</p>
   </footer>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,9 @@
+const toggle = document.getElementById('navToggle');
+const navList = document.getElementById('navList');
+
+if (toggle) {
+  toggle.addEventListener('click', () => {
+    navList.classList.toggle('open');
+    toggle.classList.toggle('open');
+  });
+}

--- a/services.html
+++ b/services.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>サービス紹介 - 未来テック株式会社</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>未来テック株式会社</h1>
+    <nav>
+      <button class="nav-toggle" id="navToggle" aria-label="メニュー">MENU</button>
+      <ul id="navList">
+        <li><a href="index.html#about">会社概要</a></li>
+        <li><a href="index.html#services">サービス紹介</a></li>
+        <li><a href="index.html#contact">お問い合わせ</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <section class="page-section">
+    <h2>サービス紹介</h2>
+    <p>クラウドソリューションやAI開発など、幅広いサービスを提供しています。</p>
+    <img src="https://via.placeholder.com/600x400?text=office" alt="オフィスの外観">
+  </section>
+
+  <footer>
+    <p>© 2025 未来テック株式会社</p>
+  </footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -16,7 +16,19 @@ header h1 {
   font-size: 1.5em;
 }
 
-nav ul {
+nav {
+  position: relative;
+}
+
+.nav-toggle {
+  background: none;
+  border: 1px solid #fff;
+  color: #fff;
+  padding: 5px 10px;
+  cursor: pointer;
+}
+
+#navList {
   list-style: none;
   padding: 0;
   margin: 10px 0 0;
@@ -36,6 +48,36 @@ section {
   padding: 40px 20px;
 }
 
+.about-section {
+  position: relative;
+  color: #fff;
+  text-align: center;
+  background-image: url("https://user0514.cdnw.net/shared/img/thumb/textHFKE0400_TP_V.jpg");
+  background-size: cover;
+  background-position: center;
+}
+
+.about-section::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.about-section > * {
+  position: relative;
+  z-index: 1;
+}
+
+.section-link {
+  text-decoration: none;
+  color: inherit;
+  display: block;
+}
+
 section:nth-child(even) {
   background-color: #f0f8ff;
 }
@@ -48,10 +90,29 @@ footer {
 }
 
 @media (max-width: 600px) {
-  nav ul {
+  #navList {
+    display: none;
     flex-direction: column;
+    position: absolute;
+    right: 20px;
+    top: 50px;
+    background-color: #005bbb;
+    width: 150px;
+  }
+  #navList.open {
+    display: block;
   }
   nav li {
-    margin: 5px 0;
+    margin: 5px 10px;
+  }
+}
+
+@media (min-width: 601px) {
+  .nav-toggle {
+    display: none;
+  }
+  #navList {
+    display: flex;
+    position: static;
   }
 }


### PR DESCRIPTION
## Summary
- make nav dropdown with hamburger for mobile
- add background image overlay for the about section
- add dedicated pages: about, services, contact
- make homepage sections link to dedicated pages
- include small JS helper

## Testing
- `npx htmlhint index.html` *(fails: requires installing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68493b66fef88328a7760c1cea70b355